### PR TITLE
Update Pages deploy action to Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update `actions/deploy-pages` from v4 to v5
- addresses the GitHub Actions Node.js 20 deprecation warning for Pages deployment

## Validation
- workflow-only change