### PR TITLE
Keep search icon visible on mobile

### DIFF
--- a/site-assets/stylesheets/circuswiki.css
+++ b/site-assets/stylesheets/circuswiki.css
@@ -302,6 +302,8 @@ textarea:focus-visible,
 }
 
 .md-header .md-search {
+  display: flex;
+  align-items: center;
   flex: 0 0 auto;
   width: auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- keep the custom search icon container visible below the mobile breakpoint
- preserve the icon-only header search control across desktop and mobile layouts

## Checks
- node --check site-assets/javascripts/site-theme.js
- powershell -ExecutionPolicy Bypass -File tools/check.ps1
- python tools/sync_configs.py
- powershell -ExecutionPolicy Bypass -File tools/build_multilang.ps1